### PR TITLE
Refactor login redirect

### DIFF
--- a/src/controllers/github/index.ts
+++ b/src/controllers/github/index.ts
@@ -9,7 +9,11 @@ import {
   GITHUB_ORGANIZATIONS,
 } from '../../constants/endpoints';
 
-export const loginRedirect = (_: Request, res: Response) => {
+export const loginRedirect = (req: Request, res: Response) => {
+  const { query } = req;
+
+  req.session.gitScry = { redirect: query.redirect };
+
   logger.info('Redirecting to GitHub login');
 
   const params = qs.stringify({
@@ -65,13 +69,12 @@ export const getAccessToken = async (req: Request, res: Response) => {
 
     logger.info('Received access token');
 
-    req.session.githubAccessToken = accessToken;
-    req.session.gitScry = {
-      githubAccessToken: accessToken,
-      appScope,
-    };
+    req.session.gitScry.githubAccessToken = accessToken;
+    req.session.gitScry.appScope = appScope;
 
-    res.redirect('/');
+    const uiRedirect = req.session.gitScry.redirect;
+
+    res.redirect(uiRedirect);
   } catch (err) {
     const errorMessage = err.message || 'Unable to retrieve access token';
 


### PR DESCRIPTION
This PR makes it so the UI can send a redirect link for when the user logs in through GitHub. The UI sends a redirect URL as a query parameter to the `github-login` route. Git Scry then stores that redirect URL in session data. When Git Scry successfully retrieves an access token, it'll use that session data to redirect the user to the correct page.